### PR TITLE
Use seconds for cache TTL

### DIFF
--- a/biance-main/app/bootstrap.py
+++ b/biance-main/app/bootstrap.py
@@ -34,7 +34,7 @@ async def build_app_state() -> AppState:
 
     l1_cache = LRUCache(max_items=10000)
 
-    use_get_klines = GetKlines(kline_repo, l1_cache, ttl_ms=settings.cache_ttl_ms_klines)
+    use_get_klines = GetKlines(kline_repo, l1_cache, ttl_s=settings.cache_ttl_sec_klines)
     use_health = HealthSnapshot(kline_repo)
 
     return AppState(

--- a/biance-main/app/settings.py
+++ b/biance-main/app/settings.py
@@ -15,11 +15,14 @@ class Settings(BaseSettings):
     auto_sync_symbols: bool = Field(default=True, alias="AUTO_SYNC_SYMBOLS")
     symbol_sync_interval_sec: int = Field(default=300, alias="SYMBOL_SYNC_INTERVAL_SEC")
     quote_assets: List[str] = Field(default_factory=lambda: ["USDT"], alias="QUOTE_ASSETS")
+    cache_ttl_sec_klines: int = Field(default=10, alias="CACHE_TTL_SEC_KLINES")
+    fetch_concurrency: int = Field(default=1, alias="FETCH_CONCURRENCY")
 
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
         case_sensitive = False
+        extra = "allow"
 
     @field_validator("symbols", "intervals", mode="before")
     @classmethod

--- a/biance-main/domain/usecases.py
+++ b/biance-main/domain/usecases.py
@@ -14,8 +14,10 @@ def serialize_binance_klines(bars):
     return orjson.dumps(out)
 
 class GetKlines:
-    def __init__(self, repo: KlineRepo, cache: Cache, ttl_ms: int=10000):
-        self.repo=repo; self.cache=cache; self.ttl_s=max(1, ttl_ms//1000)
+    def __init__(self, repo: KlineRepo, cache: Cache, ttl_s: int=10):
+        self.repo = repo
+        self.cache = cache
+        self.ttl_s = max(1, ttl_s)
     async def handle(self, symbol: str, interval: str,
                      start: Optional[int], end: Optional[int], limit: int,
                      only_final: bool=True):

--- a/biance-main/infra/cache/lru_cache.py
+++ b/biance-main/infra/cache/lru_cache.py
@@ -20,9 +20,9 @@ class LRUCache:
                 return None
             self._d.move_to_end(key)
             return data
-    async def set_bytes(self, key: str, data: bytes, ttl_ms: int):
+    async def set_bytes(self, key: str, data: bytes, ttl_s: int):
         async with self._lock:
-            expire = time.time() + max(1, ttl_ms // 1000)
+            expire = time.time() + max(1, ttl_s)
             self._d[key] = (data, expire)
             self._d.move_to_end(key)
             while len(self._d) > self.max_items:


### PR DESCRIPTION
## Summary
- standardize cache expiration to seconds across the project
- add TTL configuration to settings and pass it through bootstrap
- ensure settings allow extra options like fetch concurrency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b67f72a94c8325906272b10eb6bc54