### PR TITLE
Ensure ETag and cache headers in middleware

### DIFF
--- a/biance-main/infra/http/etag_middleware.py
+++ b/biance-main/infra/http/etag_middleware.py
@@ -20,10 +20,10 @@ class KlineETagMiddleware(BaseHTTPMiddleware):
             resp = new_resp
         else:
             body = await resp.body()
-        etag = hashlib.md5(body).hexdigest()
+        etag = '"' + hashlib.md5(body).hexdigest() + '"'
         inm = request.headers.get("if-none-match")
         if inm and inm == etag:
-            return Response(status_code=304)
+            return Response(status_code=304, headers={"ETag": etag, "Cache-Control": "public, max-age=10"})
         resp.headers.setdefault("ETag", etag)
         resp.headers.setdefault("Cache-Control", "public, max-age=10")
         return resp


### PR DESCRIPTION
## Summary
- generate quoted md5 hash for ETag values
- return 304 responses with ETag and cache-control headers
- default ETag and cache-control headers for 200 responses

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6ae1e1cb08325a3a3ae27fe46dfb7